### PR TITLE
Fix spark action not respecting setting

### DIFF
--- a/ActivatePowerMode/Actions/SparkAction.m
+++ b/ActivatePowerMode/Actions/SparkAction.m
@@ -51,7 +51,7 @@ NSInteger const MaxParticleCount = 100;
 
 - (void)sparkAtPosition:(CGPoint)position withColor:(NSColor *)color inView:(NSView *)view
 {
-    if (!self.isEnableAction) {
+    if (![ConfigManager sharedManager].isEnableSpark) {
         return;
     }
     


### PR DESCRIPTION
This PR fixes the issue that Sparks always become enabled when relaunching Xcode.
It didn't respect the users settings like the ShakeAction does, so now it uses the same `ConfigManager` to determine if it should be enabled or not.

``` patch
+if (![ConfigManager sharedManager].isEnableSpark) {
-if (!self.isEnableAction) {
```
